### PR TITLE
Fix typo in tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ chxcode
 Select Xcode for the current shell:
 
 ```sh
-$ chxhode 9.3
+$ chxcode 9.3
 $ chxcode
   9.2
 * 9.3


### PR DESCRIPTION
I noticed that it said `chxhode` instead of `chxcode` :)