### PR TITLE
 Read Xcode version from .tool-versions 

### DIFF
--- a/share/chxcode/auto
+++ b/share/chxcode/auto
@@ -1,13 +1,41 @@
 # shellcheck shell=bash
 
+# https://github.com/asdf-vm/asdf/blob/bd21c99a0a04018b51e528acff8d237bff8780c4/lib/utils.bash#L626-L638
+strip_tool_version_comments() {
+  local tool_version_path="$1"
+
+  while IFS= read -r tool_line || [ -n "$tool_line" ]; do
+    # Remove whitespace before pound sign, the pound sign, and everything after it
+    new_line="$(cut -f1 -d"#" <<<"$tool_line" | sed -e 's/[[:space:]]*$//')"
+
+    # Only print the line if it is not empty
+    if [[ -n "$new_line" ]]; then
+      printf "%s\\n" "$new_line"
+    fi
+  done <"$tool_version_path"
+}
+
+function version_from_file() {
+  local version
+
+  if { read -r version <"$1/.xcode-version"; } 2>/dev/null; then
+    version="${version%%[[:space:]]}"
+  elif [ -f "$1/.tool-versions" ]; then
+    version=$(strip_tool_version_comments "$1/.tool-versions" |\
+      grep "^xcode " |\
+      sed -e "s/^xcode //")
+  fi
+
+  printf '%s' "$version"
+}
+
 function chxcode_auto() {
   local dir="$PWD/" version
 
   until [[ -z "$dir" ]]; do
     dir="${dir%/*}"
-    if { read -r version <"$dir/.xcode-version"; } 2>/dev/null || [[ -n "$version" ]]; then
-      version="${version%%[[:space:]]}"
-
+    version=$(version_from_file "$dir")
+    if [[ -n "$version" ]]; then
       if [[ "$version" == "$XCODE_AUTO_VERSION" ]]; then
         return
       else

--- a/share/chxcode/chxcode
+++ b/share/chxcode/chxcode
@@ -23,9 +23,15 @@ system_xcode_version() {
 
 xcode_versions() {
   system_version=$(system_xcode_version)
+  versions=()
   for xcode in ${XCODES[*]}; do
     version=$(xcode_version "$xcode")
+    versions+=${version}
+  done
 
+  IFS=$'\n' versions=($(sort -n <<<"${versions[*]}")); unset IFS
+
+  for version in ${versions[*]}; do
     if [ "$version" = "$system_version" ]; then
       echo "* $version"
     else

--- a/share/chxcode/chxcode
+++ b/share/chxcode/chxcode
@@ -26,10 +26,10 @@ xcode_versions() {
   versions=()
   for xcode in ${XCODES[*]}; do
     version=$(xcode_version "$xcode")
-    versions+=${version}
+    versions+=("$version")
   done
 
-  IFS=$'\n' versions=($(sort -n <<<"${versions[*]}")); unset IFS
+  IFS=$'\n' versions=("$(sort -n <<<"${versions[*]}")"); unset IFS
 
   for version in ${versions[*]}; do
     if [ "$version" = "$system_version" ]; then

--- a/test/chxcode_auto_test
+++ b/test/chxcode_auto_test
@@ -39,6 +39,16 @@ test_auto_enter_versioned_directory() {
     "$DEVELOPER_DIR"
 }
 
+test_auto_enter_tool_versions_directory() {
+  echo "xcode 9.3\nruby 2.6" > "$test_project_dir/.tool-versions"
+
+  cd "$test_project_dir" && chxcode_auto
+
+  assertEquals "should switch Xcode when entering a .tool-versions directory" \
+    "$search_path/Xcode.app/Contents/Developer" \
+    "$DEVELOPER_DIR"
+}
+
 test_auto_enter_versioned_subdirectory() {
   echo "9.3" > "$test_project_dir/.xcode-version"
   mkdir "$test_project_dir/subdir"
@@ -46,6 +56,17 @@ test_auto_enter_versioned_subdirectory() {
   cd "$test_project_dir/subdir" && chxcode_auto
 
   assertEquals "should switch Xcode when entering a subdirectory of a versioned directory" \
+    "$search_path/Xcode.app/Contents/Developer" \
+    "$DEVELOPER_DIR"
+}
+
+test_auto_enter_tool_versions_subdirectory() {
+  echo "xcode 9.3\nruby2.6" > "$test_project_dir/.tool-versions"
+  mkdir "$test_project_dir/subdir"
+
+  cd "$test_project_dir/subdir" && chxcode_auto
+
+  assertEquals "should switch Xcode when entering a subdirectory of a .tool-versions directory" \
     "$search_path/Xcode.app/Contents/Developer" \
     "$DEVELOPER_DIR"
 }

--- a/test/chxcode_test
+++ b/test/chxcode_test
@@ -3,7 +3,7 @@
 . ./test/helper
 
 test_exec_with_no_arguments() {
- export DEVELOPER_DIR="$search_path/Xcode.app/Contents/Developer"
+  export DEVELOPER_DIR="$search_path/Xcode.app/Contents/Developer"
 
   xcodes=$(chxcode | tr '\n' ' ' | xargs)
 


### PR DESCRIPTION
asdf uses `.tool-versions` to control the expected version of multiple
tools. This prevents having to define separate files for each tool
(`.ruby-version`, `.node-version`, etc).

This adds support to read Xcode version from `.tool-versions`.

