### PR TITLE
Sort versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - run: mdutil -s /
+
+    - run: sudo mdutil -E /
+
     - name: Install shunit2
       run: brew install shunit2
+
+    - name: Wait for spotlight to index our test Xcodes directory
+      run: ./bin/wait-for-spotlight
+
+    - name: Run mdfind
+      run: mdfind -onlyin "$PWD/test/applications" "kMDItemCFBundleIdentifier='com.apple.dt.Xcode'"
 
     - name: Run tests
       run: make test

--- a/bin/wait-for-spotlight
+++ b/bin/wait-for-spotlight
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+xcodes_path="$PWD/test/applications"
+
+while true; do
+  mdimport "$xcodes_path"
+  mdls "$xcodes_path"
+
+  output="$(mdfind -onlyin "$xcodes_path" "kMDItemCFBundleIdentifier='com.apple.dt.Xcode'")"
+
+  if [ -z "$output" ]; then
+    echo "mdfind did not find any Xcodes at $xcodes_path"
+    ls "$xcodes_path"
+    sleep 1
+  else
+    echo "found '$output'"
+    break
+  fi
+done

--- a/share/chxcode/chxcode
+++ b/share/chxcode/chxcode
@@ -23,9 +23,15 @@ system_xcode_version() {
 
 xcode_versions() {
   system_version=$(system_xcode_version)
+  versions=()
   for xcode in ${XCODES[*]}; do
     version=$(xcode_version "$xcode")
+    versions+=${version}
+  done
 
+  IFS=$'\n' versions=($(sort -n <<<"${versions[*]}")); unset IFS
+
+  for version in ${versions[*]}; do
     if [ "$version" = "$system_version" ]; then
       echo "* $version"
     else

--- a/share/chxcode/chxcode
+++ b/share/chxcode/chxcode
@@ -26,7 +26,7 @@ xcode_versions() {
   versions=()
   for xcode in ${XCODES[*]}; do
     version=$(xcode_version "$xcode")
-    versions+=${version}
+    versions+=("$version")
   done
 
   IFS=$'\n' versions=($(sort -n <<<"${versions[*]}")); unset IFS

--- a/test/chxcode_test
+++ b/test/chxcode_test
@@ -3,11 +3,11 @@
 . ./test/helper
 
 test_exec_with_no_arguments() {
- export DEVELOPER_DIR="$search_path/Xcode.app/Contents/Developer"
+  export DEVELOPER_DIR="$search_path/Xcode.app/Contents/Developer"
 
   xcodes=$(chxcode | tr '\n' ' ' | xargs)
 
-  assertEquals "should print installed xcodes" "9.2 * 9.3" "$xcodes"
+  assertEquals "should print installed xcodes" "* 9.3 9.2" "$xcodes"
 }
 
 test_change_unknown_xcode_reports_error() {

--- a/test/chxcode_test
+++ b/test/chxcode_test
@@ -7,7 +7,7 @@ test_exec_with_no_arguments() {
 
   xcodes=$(chxcode | tr '\n' ' ' | xargs)
 
-  assertEquals "should print installed xcodes" "* 9.3 9.2" "$xcodes"
+  assertEquals "should print installed xcodes" "9.2 * 9.3" "$xcodes"
 }
 
 test_change_unknown_xcode_reports_error() {


### PR DESCRIPTION
Some tests were failing because our sort order was depending on the
order `mdfind` was returning Xcodes. This uses sort -n to sort versions
by their numeric order.
